### PR TITLE
Update podman-machine.rb

### DIFF
--- a/Formula/podman-machine.rb
+++ b/Formula/podman-machine.rb
@@ -9,6 +9,6 @@ class PodmanMachine < Formula
   def install
     mv "podman-machine.darwin-amd64", "podman-machine"
     bin.install "podman-machine"
-    
+ 
   end
 end

--- a/Formula/podman-machine.rb
+++ b/Formula/podman-machine.rb
@@ -9,6 +9,6 @@ class PodmanMachine < Formula
   def install
     mv "podman-machine.darwin-amd64", "podman-machine"
     bin.install "podman-machine"
- 
+
   end
 end

--- a/Formula/podman-machine.rb
+++ b/Formula/podman-machine.rb
@@ -1,1 +1,14 @@
-TODO: add formula code
+class PodmanMachine < Formula
+  desc ""
+  homepage "https://github.com/boot2podman/machine"
+  url "https://github.com/boot2podman/machine/releases/download/v0.17/podman-machine.darwin-amd64"
+  sha256 "079bc9941d7479214149d0d38599489fab1164f56721b333714b8817cef5e88a"
+
+   depends_on 'qemu'
+
+  def install
+    mv "podman-machine.darwin-amd64", "podman-machine"
+    bin.install "podman-machine"
+    
+  end
+end

--- a/README.md
+++ b/README.md
@@ -9,7 +9,40 @@ Or install via URL (which will not receive updates):
 
 ```
 brew install https://raw.githubusercontent.com/ttu-capstone-podman/homebrew-podman-machine/master/Formula/<formula>.rb
+
 ```
+## Dependencies
+Automatically Installs [QEMU](https://www.qemu.org) as the Virtual Machine, can use Virtual Box if installed Manually.
+
+## How to use
+Once installed can be ran from terminal using:
+
+```
+podman-machine
+
+```
+Switch between VM's by using 
+
+```
+podman-machine --driver qemu
+
+```
+or 
+
+```
+podman-machine --driver virtualbox
+
+```
+
+
+## Uninstall 
+To uninstall use command 
+
+```
+
+ brew uninstall --force podman-machine
+
+ ```
 
 ## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,5 +11,6 @@ jobs:
           mkdir -p "$HOMEBREW_TAP_DIR"
           rm -rf "$HOMEBREW_TAP_DIR"
           ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+          brew cleanup
           brew test-bot
         displayName: Run brew test-bot


### PR DESCRIPTION
adds dependency on Qemu rather than virtualbox. does the same thing but doesn't require cask or require user to go into settings to enable access